### PR TITLE
Set date in front matter for professors to sort them first

### DIFF
--- a/src/partners/florian-tschorsch.md
+++ b/src/partners/florian-tschorsch.md
@@ -2,6 +2,7 @@
 name: Prof. Dr. Florian Tschorsch
 image: florian-tschorsch.jpg
 tags: tub
+date: 2000-01-01
 ---
 
 {% include ./schools/tub.md %}

--- a/src/partners/helena-mihaljevic.md
+++ b/src/partners/helena-mihaljevic.md
@@ -2,6 +2,7 @@
 name: Prof. Dr. Helena Mihaljević
 image: helena-mihaljevic.jpg
 tags: htw
+date: 2000-01-01
 ---
 
 {% include ./schools/htw.md %}

--- a/src/partners/max-grafenstein.md
+++ b/src/partners/max-grafenstein.md
@@ -2,6 +2,7 @@
 name: Prof. Dr. Max von Grafenstein LL.M.
 image: max-grafenstein.jpg
 tags: udk
+date: 2000-01-01
 ---
 
 {% include ./schools/udk.md %}


### PR DESCRIPTION
11ty sorts collections by default with the date attribute which by default is when the file was created. Setting an earlier date allows you to get certain items sorted to the start. We want to start with the professors so adding 'date: 2000-01-01' into the front matter of the files got the job done
 