### PR TITLE
fix(FREEMOVE-393): make FU Berlin visible in mobile nav

### DIFF
--- a/src/_includes/partials/header.liquid
+++ b/src/_includes/partials/header.liquid
@@ -125,7 +125,10 @@
     <a href="javascript:" class="no-underline">PROJEKTPARTNER:INNEN</a>
     <button class="border-blue component-down-arrow mr-5 focus:outline-none"></button>
     <div class="hidden w-full" class="no-underline">
-      <a href="/partners/dlr">
+      <a href="/partners/fub" class="no-underline">
+        <p class="text-white text-base">{{ schools.fub.de }}</p>
+      </a>
+      <a href="/partners/dlr" class="no-underline">
         <p class="text-white text-base">{{ schools.dlr.de }}</p>
       </a>
       <a href="/partners/htw" class="no-underline">


### PR DESCRIPTION
This PR makes the partner _Freie Universität Berlin_ visible in the mobile nav. It had simply been forgotten before.