### PR TITLE
feat(FREEMOVE-437): add conclusion banner to Erhebung page

### DIFF
--- a/src/erhebung/index.liquid
+++ b/src/erhebung/index.liquid
@@ -5,7 +5,11 @@ subtitle: 14 Tage Mobilitätsdatenerhebung via App
 permalink: /erhebung/
 ---
 
-<h1 class="text-orange">{{ title }}</h1>
+<div class="border border-orange px-5 py-3 rounded-md">
+  <p class="text-2xl text-orange"><strong>Geschafft!</strong> Wir danken allen Teilnehmenden fürs Mitmachen und freuen uns bald Ergebnisse mit euch teilen zu dürfen!</p>
+</div>
+
+<h1 class="mt-16 text-orange">{{ title }}</h1>
 <h2 class="mt-2 text-orange font-normal">{{ subtitle }}</h2>
 
 <div class="mt-16 grid md:grid-cols-[144px,1fr] gap-8">


### PR DESCRIPTION
**Attention**: Only merge this after all todo's below are completed!

---

This PR adds a banner informing about the conclusion of the Erhebung to the Erhebung page itself.

- [ ] remove banner from homepage
- [ ] find way to get to Erhebung page without homepage banner
- [ ] get OK to merge this from Markus